### PR TITLE
Add C-SEO Bench (NeurIPS D&B 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Generative Engine Optimization (GEO), is a paradigm to aid content creators in i
 
 This is a niche area, which is increasingly receiving attention from the community. This awesome‑listing is an attempt to bring together works in this space. This list is not complete and looking for your PRs to improve it. Thanks!
 
-## 2025
-- DYNAMICS OF ADVERSARIAL ATTACKS ON LARGE  
-  LANGUAGE MODEL‑BASED SEARCH ENGINES [[Paper]](https://arxiv.org/pdf/2501.00745)
+## 2025
+
+- C-SEO Bench: Does Conversational SEO Work?, NeurIPS D&B 2025, [[Paper]](https://arxiv.org/abs/2506.11097) [[Code]](https://github.com/parameterlab/c-seo-bench) [[Dataset]](https://huggingface.co/datasets/parameterlab/c-seo-bench)
+- Dynamics Of Adversarial Attacks On Large Language Model‑Based Search Engines [[Paper]](https://arxiv.org/pdf/2501.00745)
 - White Hat Search Engine Optimization using Large Language Models [[Paper]](https://arxiv.org/abs/2502.07315) 
 - PoisonArena: Uncovering Competing Poisoning Attacks in Retrieval‑Augmented Generation [[Paper]](https://arxiv.org/abs/2505.12574)
 - Beyond SEO: A Transformer‑Based Approach for Reinventing Web Content Optimisation [[Paper]](https://chatpaper.com/chatpaper/paper/158775)
@@ -20,12 +21,13 @@ This is a niche area, which is increasingly receiving attention from the communi
 - Role‑Augmented Intent‑Driven Generative Search Engine Optimization [[Paper]](https://arxiv.org/abs/2508.11158)
 - StealthRank: LLM Ranking Manipulation via Stealthy Prompt Optimization [[Paper]](https://arxiv.org/abs/2504.05804)
 
-## 2024
-- GASLITEING THE RETRIEVAL: EXPLORING VULNERABILITIES IN DENSE EMBEDDING‑BASED SEARCH [[Paper]](https://arxiv.org/pdf/2412.20953)
+## 2024
+
+- GASLITeing The Retrieval: Exploring Vulnerabilities In Dense Embedding‑Based Search [[Paper]](https://arxiv.org/pdf/2412.20953)
 - GEO: Generative Engine Optimization [[Paper]](https://arxiv.org/pdf/2311.09735)
 - What Evidence Do Language Models Find Convincing? [[Paper]](https://arxiv.org/html/2402.11782v1)
 - CONFLICTBANK: A Benchmark for Evaluating Knowledge Conflicts in Large Language Models [[Paper]](https://arxiv.org/abs/2408.12076)
 - Adversarial Search Engine Optimization for Large Language Models [[Paper]](https://arxiv.org/abs/2406.18382)
 - Ranking Manipulation for Conversational Search Engines [[Paper]](https://arxiv.org/abs/2406.03589)
-- PERSISTENT PRE‑TRAINING POISONING OF LLMS [[Paper]](https://arxiv.org/abs/2410.13722)
+- Persistent Pre‑Training Poisoning Of LLMs [[Paper]](https://arxiv.org/abs/2410.13722)
 - Manipulating Large Language Models to Increase Product Visibility [[Paper]](https://arxiv.org/pdf/2404.07981)


### PR DESCRIPTION
This PR:
- adds the "C-SEO Bench: Does Conversational SEO Work?" paper accepted at NeurIPS D&B 2025
- fix the markdown formatting and uniformize case