### PR TITLE
Fix DOI on the 167,551-citation study (wrong Zenodo record)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a niche area, which is increasingly receiving attention from the communi
 - IF-GEO: Conflict-Aware Instruction Fusion for Multi-Query Generative Engine Optimization [[Paper]](https://arxiv.org/abs/2601.13938)
 - Multimodal Generative Engine Optimization: Rank Manipulation for Vision–Language Model Rankers [[Paper]](https://arxiv.org/abs/2601.12263)
 - Navigating the Shift: A Comparative Analysis of Web Search and Generative AI Response Generation [[Paper]](https://arxiv.org/abs/2601.16858)
-- Source Composition of AI Answers: An Analysis of 167,551 Citations Across Generative Engines (Rankfor.AI, 2026) [[Paper]](https://doi.org/10.5281/zenodo.20788142)
+- Source Composition of AI Answers: An Analysis of 167,551 Citations Across Generative Engines (Rankfor.AI, 2026) [[Paper]](https://doi.org/10.5281/zenodo.20829524)
 
 ## 2025
 


### PR DESCRIPTION
Small correction to an entry I added in #7.

The line **"Source Composition of AI Answers: An Analysis of 167,551 Citations Across Generative Engines"** links to `10.5281/zenodo.20788142`. That DOI actually resolves to a different dataset, **"Category Ownership Map (COI/CVI/DS)"** (3,750 LLM responses).

The 167,551-citation study has its own DOI: **10.5281/zenodo.20829524** ("How LLMs Source Brand Reputation Across Languages and Markets: A Cross-Market Citation Dataset, 2026"). This PR swaps the link to the correct record.

Disclosure: I'm the author of both datasets; caught the mix-up during our own review.